### PR TITLE
Removed read current members support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ tags
 
 terraform-provider-slack
 terraform-provider-slack_*
+/examples/terraform.tfstate
+/examples/terraform.tfstate.backup
+/examples/.terraform/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,3 @@
-CHANGE_HOST?=localhost
 TEST?=$$(go list ./... |grep -v 'vendor')
 SWEEP_DIR?=./change
 SWEEP?=$(CHANGE_ADDRESS)
@@ -13,7 +12,6 @@ bin:
 tools:
 	@echo "==> Installing external tools..."
 	GO111MODULE=on go get -u golang.org/x/lint/golint
-	GO111MODULE=on go get -u gotest.tools/gotestsum
 	GO111MODULE=on go get -u github.com/gordonklaus/ineffassign
 	GO111MODULE=on go get -u github.com/client9/misspell/cmd/misspell
 	GO111MODULE=on go get -u github.com/katbyte/terrafmt
@@ -26,7 +24,7 @@ fmt:
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
-lint: tools fmtcheck vet docs
+lint: tools fmtcheck vet #docs
 	@echo "==> Checking source code against linters..."
 	golint -set_exit_status $$(find . -type d | grep -v vendor)
 	ineffassign .
@@ -40,7 +38,7 @@ test: lint
 
 testacc: lint
 	@echo "==> Running acceptance tests..."
-	TF_ACC=1 CHANGE_HOST=$(CHANGE_HOST) go test $(TEST)
+	TF_ACC=1 go test -v $(TEST)
 
 vet:
 	@echo "go vet ."
@@ -82,4 +80,4 @@ docscheck:
 		-require-resource-subcategory
 	@misspell -error -source text CHANGELOG.md
 
-.PHONY: build tools fmt fmtcheck lint sweep test testacc vet depscheck docs docs-lint docs-lint-fix docscheck change-image
+.PHONY: build tools fmt fmtcheck lint sweep test testacc vet depscheck docs docs-lint docs-lint-fix docscheck

--- a/docs/data-sources/conversation.md
+++ b/docs/data-sources/conversation.md
@@ -27,7 +27,6 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `name` - name of the public or private channel.
-* `members` - user IDs of users in the channel.
 * `topic` - topic for the channel.
 * `purpose` - purpose of the channel.
 * `creator` - is the user ID of the member that created this channel.

--- a/docs/resources/conversation.md
+++ b/docs/resources/conversation.md
@@ -34,7 +34,6 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The channel ID (e.g. C015QDUB7ME).
-* `members` - user IDs of users in the channel.
 * `creator` - is the user ID of the member that created this channel.
 * `created` - is a unix timestamp.
 * `is_shared` - means the conversation is in some way shared between multiple workspaces.

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,14 +1,14 @@
-provider slack {
-  token   = var.slack_token
+data slack_user test_user_00 {
+  name = "contact_test-user-ter"
 }
 
-data slack_user aws_chat_bot {
-  name = "aws"
+data slack_user test_user_01 {
+  name = "contact_test-user-206"
 }
 
 resource slack_conversation aws_chatbot {
-  name       = "aws-chat-bot-notifications"
-  topic      = "AWS ChatBot Notifications"
-  members    = [data.slack_user.aws_chat_bot.id]
-  is_private = true
+  name              = "aws-chat-bot-notifications-pablo"
+  topic             = "AWS ChatBot Notifications"
+  permanent_members = [data.slack_user.test_user_01.id, data.slack_user.test_user_00.id]
+  is_private        = true
 }

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -1,3 +1,0 @@
-variable slack_token {
-  type = string
-}

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    slack = {
+      source  = "pablovarela/slack"
+      version = "~> 0.1"
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bflad/tfproviderdocs v0.7.0 // indirect
-	github.com/bmatcuk/doublestar v1.3.2 // indirect
+	github.com/bmatcuk/doublestar v1.3.3 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/google/go-cmp v0.5.2 // indirect
@@ -41,9 +42,9 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/zclconf/go-cty v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
-	golang.org/x/net v0.0.0-20201022231255-08b38378de70 // indirect
-	golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd // indirect
-	golang.org/x/tools v0.0.0-20201023150057-2f4fa188d925 // indirect
+	golang.org/x/net v0.0.0-20201024042810-be3efd7ff127 // indirect
+	golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5 // indirect
+	golang.org/x/tools v0.0.0-20201023174141-c8cfbd0f21e6 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gotest.tools/gotestsum v0.5.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/bmatcuk/doublestar v1.2.1 h1:eetYiv8DDYOZcBADY+pRvRytf3Dlz1FhnpvL2FsC
 github.com/bmatcuk/doublestar v1.2.1/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmatcuk/doublestar v1.3.2 h1:mzUncgFmpzNUhIITFqGdZ8nUU0O7JTJzRO8VdkeLCSo=
 github.com/bmatcuk/doublestar v1.3.2/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
+github.com/bmatcuk/doublestar v1.3.3 h1:pVP1d49CcQQaNOl+PI6sPybIrIOD/6sux31PFdmhTH0=
+github.com/bmatcuk/doublestar v1.3.3/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -606,6 +608,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjN
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201022231255-08b38378de70 h1:Z6x4N9mAi4oF0TbHweCsH618MO6OI6UFgV0FP5n0wBY=
 golang.org/x/net v0.0.0-20201022231255-08b38378de70/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201024042810-be3efd7ff127 h1:pZPp9+iYUqwYKLjht0SDBbRCRK/9gAXDy7pz5fRDpjo=
+golang.org/x/net v0.0.0-20201024042810-be3efd7ff127/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -664,6 +668,10 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd h1:WgqgiQvkiZWz7XLhphjt2GI2GcGCTIZs9jqXMWmH+oc=
 golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201024132449-ef9fd89ba245 h1:GGQcbpn3KsnwsPvzzr1mDsTriyvGNKi9eo2lG3N8YdM=
+golang.org/x/sys v0.0.0-20201024132449-ef9fd89ba245/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5 h1:iCaAy5bMeEvwANu3YnJfWwI0kWAGkEa2RXPdweI/ysk=
+golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -719,6 +727,10 @@ golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed h1:+qzWo37K31KxduIYaBeMqJ8
 golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20201022215848-ffe8bce740af h1:L1EV/2WjPBRxjdgDu0bbZ5gWPuQ6yX9HjG6hSb2dFV4=
 golang.org/x/tools v0.0.0-20201022215848-ffe8bce740af/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20201023150057-2f4fa188d925 h1:iGGR3nU1TUd+WTF17QPTTShBEDG66IKsDIDKtC4EseY=
+golang.org/x/tools v0.0.0-20201023150057-2f4fa188d925/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20201023174141-c8cfbd0f21e6 h1:rbvTkL9AkFts1cgI78+gG6Yu1pwaqX6hjSJAatB78E4=
+golang.org/x/tools v0.0.0-20201023174141-c8cfbd0f21e6/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/slack/data_source_conversation.go
+++ b/slack/data_source_conversation.go
@@ -25,6 +25,7 @@ func dataSourceConversation() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				Set:      schema.HashString,
 				Computed: true,
 			},
 			"topic": {

--- a/slack/data_source_conversation.go
+++ b/slack/data_source_conversation.go
@@ -20,14 +20,6 @@ func dataSourceConversation() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"members": {
-				Type: schema.TypeSet,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-				Set:      schema.HashString,
-				Computed: true,
-			},
 			"topic": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/slack/data_source_conversation.go
+++ b/slack/data_source_conversation.go
@@ -73,13 +73,6 @@ func dataSourceConversation() *schema.Resource {
 
 func dataSourceSlackConversationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*slack.Client)
-
 	channelID := d.Get("channel_id").(string)
-
-	channel, err := client.GetConversationInfoContext(ctx, channelID, false)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	return updateChannelData(d, channel)
+	return readChannelInfo(ctx, d, client, channelID)
 }

--- a/slack/data_source_conversation_test.go
+++ b/slack/data_source_conversation_test.go
@@ -17,8 +17,8 @@ func TestAccSlackConversationDataSource_basic(t *testing.T) {
 
 	var providers []*schema.Provider
 	name := acctest.RandomWithPrefix("test-acc-slack-conversation-test")
-	var members = []string{testUser00.id}
-	createChannel := testAccSlackConversation(name, members)
+	var members = []string{testUser00.id, testUser01.id}
+	createChannel := testAccSlackConversationWithMembers(name, members)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/slack/data_source_conversation_test.go
+++ b/slack/data_source_conversation_test.go
@@ -44,6 +44,7 @@ func TestAccSlackConversationDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "is_ext_shared", resourceName, "is_ext_shared"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "is_org_shared", resourceName, "is_org_shared"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "is_general", resourceName, "is_general"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "members", resourceName, "members"),
 				),
 			},
 		},

--- a/slack/data_source_conversation_test.go
+++ b/slack/data_source_conversation_test.go
@@ -44,7 +44,6 @@ func TestAccSlackConversationDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "is_ext_shared", resourceName, "is_ext_shared"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "is_org_shared", resourceName, "is_org_shared"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "is_general", resourceName, "is_general"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "members", resourceName, "members"),
 				),
 			},
 		},

--- a/slack/data_source_conversation_test.go
+++ b/slack/data_source_conversation_test.go
@@ -17,7 +17,7 @@ func TestAccSlackConversationDataSource_basic(t *testing.T) {
 
 	var providers []*schema.Provider
 	name := acctest.RandomWithPrefix("test-acc-slack-conversation-test")
-	var members = []string{nonAuthenticatedTestUserID}
+	var members = []string{testUser00.id}
 	createChannel := testAccSlackConversation(name, members)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -59,7 +59,7 @@ func testAccCheckSlackConversationDataSourceID(n string) resource.TestCheckFunc 
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("slack conversation data source ID not set")
+			return fmt.Errorf("slack conversation data source id not set")
 		}
 		return nil
 	}

--- a/slack/data_source_user.go
+++ b/slack/data_source_user.go
@@ -28,7 +28,7 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	users, err := client.GetUsersContext(ctx)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("couldn't get workspace users: %s", err)
 	}
 
 	var matchingUsers []slack.User

--- a/slack/data_source_user_test.go
+++ b/slack/data_source_user_test.go
@@ -26,8 +26,8 @@ func TestAccSlackUserDataSource_basic(t *testing.T) {
 				Config: testAccCheckSlackUserDataSourceConfigExistent,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSlackUserDataSourceID(dataSourceName),
-					resource.TestCheckResourceAttr(dataSourceName, "name", testUserName),
-					resource.TestCheckResourceAttr(dataSourceName, "id", testUserID),
+					resource.TestCheckResourceAttr(dataSourceName, "name", testUserCreator.name),
+					resource.TestCheckResourceAttr(dataSourceName, "id", testUserCreator.id),
 				),
 			},
 		},
@@ -42,7 +42,7 @@ func testAccCheckSlackUserDataSourceID(n string) resource.TestCheckFunc {
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("slack conversation data source ID not set")
+			return fmt.Errorf("slack conversation data source id not set")
 		}
 		return nil
 	}
@@ -54,12 +54,12 @@ data slack_user test {
  name = "non-existent"
 }
 `
-	testAccCheckSlackUserDataSourceConfigExistent = `
+)
+
+var (
+	testAccCheckSlackUserDataSourceConfigExistent = fmt.Sprintf(`
 data slack_user test {
- name = "pablo.varelapaz"
+ name = "%s"
 }
-`
-	testUserID                 = "U0150MARZEY"
-	nonAuthenticatedTestUserID = "U014V8XMMB5"
-	testUserName               = "pablo.varelapaz"
+`, testUserCreator.name)
 )

--- a/slack/provider.go
+++ b/slack/provider.go
@@ -111,10 +111,20 @@ func updateChannelData(d *schema.ResourceData, channel *slack.Channel, users []s
 	}
 
 	sort.Strings(users)
-	fmt.Printf("[DEBUG] users:%s\n", users)
+	fmt.Printf("[DEBUG] current users:%s\n", schemaSetToSlice(d.Get("members").(*schema.Set)))
+	fmt.Printf("[DEBUG] new users:%s\n", users)
 	if err := d.Set("members", users); err != nil {
 		return diag.Errorf("error setting members: %s", err)
 	}
+	fmt.Printf("[DEBUG] updated users:%s\n", schemaSetToSlice(d.Get("members").(*schema.Set)))
 
 	return nil
+}
+
+func schemaSetToSlice(set *schema.Set) []string {
+	s := make([]string, len(set.List()))
+	for i, v := range set.List() {
+		s[i] = v.(string)
+	}
+	return s
 }

--- a/slack/provider.go
+++ b/slack/provider.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"context"
-	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/slack-go/slack"
@@ -111,12 +110,12 @@ func updateChannelData(d *schema.ResourceData, channel *slack.Channel, users []s
 	}
 
 	sort.Strings(users)
-	fmt.Printf("[DEBUG] current users:%s\n", schemaSetToSlice(d.Get("members").(*schema.Set)))
-	fmt.Printf("[DEBUG] new users:%s\n", users)
+	//	fmt.Printf("[DEBUG] current users:%s\n", schemaSetToSlice(d.Get("members").(*schema.Set)))
+	//	fmt.Printf("[DEBUG] new users:%s\n", users)
 	if err := d.Set("members", users); err != nil {
 		return diag.Errorf("error setting members: %s", err)
 	}
-	fmt.Printf("[DEBUG] updated users:%s\n", schemaSetToSlice(d.Get("members").(*schema.Set)))
+	//	fmt.Printf("[DEBUG] updated users:%s\n", schemaSetToSlice(d.Get("members").(*schema.Set)))
 
 	return nil
 }

--- a/slack/provider.go
+++ b/slack/provider.go
@@ -110,12 +110,9 @@ func updateChannelData(d *schema.ResourceData, channel *slack.Channel, users []s
 	}
 
 	sort.Strings(users)
-	//	fmt.Printf("[DEBUG] current users:%s\n", schemaSetToSlice(d.Get("members").(*schema.Set)))
-	//	fmt.Printf("[DEBUG] new users:%s\n", users)
 	if err := d.Set("members", users); err != nil {
 		return diag.Errorf("error setting members: %s", err)
 	}
-	//	fmt.Printf("[DEBUG] updated users:%s\n", schemaSetToSlice(d.Get("members").(*schema.Set)))
 
 	return nil
 }

--- a/slack/provider.go
+++ b/slack/provider.go
@@ -5,7 +5,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/slack-go/slack"
-	"sort"
 )
 
 // Provider returns a *schema.Provider
@@ -42,79 +41,6 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	}
 	slackClient := slack.New(token.(string))
 	return slackClient, diags
-}
-
-func readChannelInfo(ctx context.Context, d *schema.ResourceData, client *slack.Client, id string) diag.Diagnostics {
-	channel, err := client.GetConversationInfoContext(ctx, id, false)
-	if err != nil {
-		return diag.Errorf("couldn't get conversation info for %s: %s", id, err)
-	}
-
-	users, _, err := client.GetUsersInConversationContext(ctx, &slack.GetUsersInConversationParameters{
-		ChannelID: channel.ID,
-	})
-	if err != nil {
-		return diag.Errorf("couldn't get users in conversation for %s: %s", channel.ID, err)
-	}
-	return updateChannelData(d, channel, users)
-}
-
-func updateChannelData(d *schema.ResourceData, channel *slack.Channel, users []string) diag.Diagnostics {
-	if channel.ID == "" {
-		return diag.Errorf("error setting id: returned channel does not have an id")
-	}
-	d.SetId(channel.ID)
-
-	if err := d.Set("name", channel.Name); err != nil {
-		return diag.Errorf("error setting name: %s", err)
-	}
-
-	if err := d.Set("topic", channel.Topic.Value); err != nil {
-		return diag.Errorf("error setting topic: %s", err)
-	}
-
-	if err := d.Set("purpose", channel.Purpose.Value); err != nil {
-		return diag.Errorf("error setting purpose: %s", err)
-	}
-
-	if err := d.Set("is_archived", channel.IsArchived); err != nil {
-		return diag.Errorf("error setting is_archived: %s", err)
-	}
-
-	if err := d.Set("is_shared", channel.IsShared); err != nil {
-		return diag.Errorf("error setting is_shared: %s", err)
-	}
-
-	if err := d.Set("is_ext_shared", channel.IsExtShared); err != nil {
-		return diag.Errorf("error setting is_ext_shared: %s", err)
-	}
-
-	if err := d.Set("is_org_shared", channel.IsOrgShared); err != nil {
-		return diag.Errorf("error setting is_org_shared: %s", err)
-	}
-
-	if err := d.Set("created", channel.Created); err != nil {
-		return diag.Errorf("error setting created: %s", err)
-	}
-
-	if err := d.Set("creator", channel.Creator); err != nil {
-		return diag.Errorf("error setting creator: %s", err)
-	}
-
-	if err := d.Set("is_private", channel.IsPrivate); err != nil {
-		return diag.Errorf("error setting is_private: %s", err)
-	}
-
-	if err := d.Set("is_general", channel.IsGeneral); err != nil {
-		return diag.Errorf("error setting is_general: %s", err)
-	}
-
-	sort.Strings(users)
-	if err := d.Set("members", users); err != nil {
-		return diag.Errorf("error setting members: %s", err)
-	}
-
-	return nil
 }
 
 func schemaSetToSlice(set *schema.Set) []string {

--- a/slack/provider_test.go
+++ b/slack/provider_test.go
@@ -6,6 +6,28 @@ import (
 	"testing"
 )
 
+type testUser struct {
+	id   string
+	name string
+}
+
+var (
+	testUserCreator = testUser{
+		id:   "U01D6L97N0M",
+		name: "contact",
+	}
+
+	testUser00 = testUser{
+		id:   "U01D31S1GUE",
+		name: "contact_test-user-ter",
+	}
+
+	testUser01 = testUser{
+		id:   "U01DZK10L1W",
+		name: "contact_test-user-206",
+	}
+)
+
 var testAccProvider *schema.Provider
 var testAccProviderFactories func(providers *[]*schema.Provider) map[string]func() (*schema.Provider, error)
 

--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -123,10 +123,7 @@ func updateChannelMembers(d *schema.ResourceData, client *slack.Client, channelI
 	fmt.Printf("[DEBUG] updating members: %d\n", members.Len())
 
 	if members.Len() != 0 {
-		userIds := make([]string, len(members.List()))
-		for i, v := range members.List() {
-			userIds[i] = v.(string)
-		}
+		userIds := schemaSetToSlice(members)
 		fmt.Printf("[DEBUG] updating members %s\n", userIds)
 
 		if _, err := client.InviteUsersToConversation(channelID, userIds...); err != nil {

--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/slack-go/slack"
-	"sort"
 )
 
 func resourceSlackConversation() *schema.Resource {
@@ -41,14 +40,6 @@ func resourceSlackConversation() *schema.Resource {
 				},
 				Set:      schema.HashString,
 				Optional: true,
-			},
-			"members": {
-				Type: schema.TypeSet,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-				Set:      schema.HashString,
-				Computed: true,
 			},
 			"created": {
 				Type:     schema.TypeInt,
@@ -275,11 +266,6 @@ func updateChannelData(d *schema.ResourceData, channel *slack.Channel, users []s
 
 	if err := d.Set("is_general", channel.IsGeneral); err != nil {
 		return diag.Errorf("error setting is_general: %s", err)
-	}
-
-	sort.Strings(users)
-	if err := d.Set("members", users); err != nil {
-		return diag.Errorf("error setting members: %s", err)
 	}
 
 	return nil

--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -129,11 +129,8 @@ func resourceSlackConversationCreate(ctx context.Context, d *schema.ResourceData
 
 func updateChannelMembers(d *schema.ResourceData, client *slack.Client, channelID string) error {
 	members := d.Get("permanent_members").(*schema.Set)
-	//	fmt.Printf("[DEBUG] updating members: %d\n", members.Len())
-
 	if members.Len() != 0 {
 		userIds := schemaSetToSlice(members)
-		//		fmt.Printf("[DEBUG] updating members %s\n", userIds)
 
 		if _, err := client.InviteUsersToConversation(channelID, userIds...); err != nil {
 			if err.Error() != "already_in_channel" {
@@ -155,8 +152,10 @@ func resourceSlackConversationUpdate(ctx context.Context, d *schema.ResourceData
 
 	id := d.Id()
 
-	if _, err := client.RenameConversationContext(ctx, id, d.Get("name").(string)); err != nil {
-		return diag.Errorf("couldn't rename conversation: %s", err)
+	if d.HasChange("name") {
+		if _, err := client.RenameConversationContext(ctx, id, d.Get("name").(string)); err != nil {
+			return diag.Errorf("couldn't rename conversation: %s", err)
+		}
 	}
 
 	if d.HasChange("topic") {

--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -114,17 +114,26 @@ func resourceSlackConversationCreate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
+	if isArchived, ok := d.GetOk("is_archived"); ok {
+		if isArchived.(bool) {
+			err := archiveConversationWithContext(ctx, client, channel.ID)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
 	d.SetId(channel.ID)
 	return resourceSlackConversationRead(ctx, d, m)
 }
 
 func updateChannelMembers(d *schema.ResourceData, client *slack.Client, channelID string) error {
 	members := d.Get("permanent_members").(*schema.Set)
-	fmt.Printf("[DEBUG] updating members: %d\n", members.Len())
+	//	fmt.Printf("[DEBUG] updating members: %d\n", members.Len())
 
 	if members.Len() != 0 {
 		userIds := schemaSetToSlice(members)
-		fmt.Printf("[DEBUG] updating members %s\n", userIds)
+		//		fmt.Printf("[DEBUG] updating members %s\n", userIds)
 
 		if _, err := client.InviteUsersToConversation(channelID, userIds...); err != nil {
 			if err.Error() != "already_in_channel" {

--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/slack-go/slack"
+	"sort"
 )
 
 func resourceSlackConversation() *schema.Resource {
@@ -198,15 +199,6 @@ func resourceSlackConversationUpdate(ctx context.Context, d *schema.ResourceData
 	return resourceSlackConversationRead(ctx, d, m)
 }
 
-func archiveConversationWithContext(ctx context.Context, client *slack.Client, id string) error {
-	if err := client.ArchiveConversationContext(ctx, id); err != nil {
-		if err.Error() != "already_archived" {
-			return fmt.Errorf("couldn't archive conversation %s: %s", id, err)
-		}
-	}
-	return nil
-}
-
 func resourceSlackConversationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	client := m.(*slack.Client)
@@ -218,4 +210,86 @@ func resourceSlackConversationDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	return diags
+}
+
+func readChannelInfo(ctx context.Context, d *schema.ResourceData, client *slack.Client, id string) diag.Diagnostics {
+	channel, err := client.GetConversationInfoContext(ctx, id, false)
+	if err != nil {
+		return diag.Errorf("couldn't get conversation info for %s: %s", id, err)
+	}
+
+	users, _, err := client.GetUsersInConversationContext(ctx, &slack.GetUsersInConversationParameters{
+		ChannelID: channel.ID,
+	})
+	if err != nil {
+		return diag.Errorf("couldn't get users in conversation for %s: %s", channel.ID, err)
+	}
+	return updateChannelData(d, channel, users)
+}
+
+func updateChannelData(d *schema.ResourceData, channel *slack.Channel, users []string) diag.Diagnostics {
+	if channel.ID == "" {
+		return diag.Errorf("error setting id: returned channel does not have an id")
+	}
+	d.SetId(channel.ID)
+
+	if err := d.Set("name", channel.Name); err != nil {
+		return diag.Errorf("error setting name: %s", err)
+	}
+
+	if err := d.Set("topic", channel.Topic.Value); err != nil {
+		return diag.Errorf("error setting topic: %s", err)
+	}
+
+	if err := d.Set("purpose", channel.Purpose.Value); err != nil {
+		return diag.Errorf("error setting purpose: %s", err)
+	}
+
+	if err := d.Set("is_archived", channel.IsArchived); err != nil {
+		return diag.Errorf("error setting is_archived: %s", err)
+	}
+
+	if err := d.Set("is_shared", channel.IsShared); err != nil {
+		return diag.Errorf("error setting is_shared: %s", err)
+	}
+
+	if err := d.Set("is_ext_shared", channel.IsExtShared); err != nil {
+		return diag.Errorf("error setting is_ext_shared: %s", err)
+	}
+
+	if err := d.Set("is_org_shared", channel.IsOrgShared); err != nil {
+		return diag.Errorf("error setting is_org_shared: %s", err)
+	}
+
+	if err := d.Set("created", channel.Created); err != nil {
+		return diag.Errorf("error setting created: %s", err)
+	}
+
+	if err := d.Set("creator", channel.Creator); err != nil {
+		return diag.Errorf("error setting creator: %s", err)
+	}
+
+	if err := d.Set("is_private", channel.IsPrivate); err != nil {
+		return diag.Errorf("error setting is_private: %s", err)
+	}
+
+	if err := d.Set("is_general", channel.IsGeneral); err != nil {
+		return diag.Errorf("error setting is_general: %s", err)
+	}
+
+	sort.Strings(users)
+	if err := d.Set("members", users); err != nil {
+		return diag.Errorf("error setting members: %s", err)
+	}
+
+	return nil
+}
+
+func archiveConversationWithContext(ctx context.Context, client *slack.Client, id string) error {
+	if err := client.ArchiveConversationContext(ctx, id); err != nil {
+		if err.Error() != "already_archived" {
+			return fmt.Errorf("couldn't archive conversation %s: %s", id, err)
+		}
+	}
+	return nil
 }

--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -124,14 +124,8 @@ func resourceSlackConversationCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceSlackConversationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*slack.Client)
-
 	id := d.Id()
-	channel, err := client.GetConversationInfoContext(ctx, id, false)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	return updateChannelData(d, channel)
+	return readChannelInfo(ctx, d, client, id)
 }
 
 func resourceSlackConversationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/slack/resource_conversation_test.go
+++ b/slack/resource_conversation_test.go
@@ -65,7 +65,7 @@ func TestAccSlackConversationTest(t *testing.T) {
 
 func testSlackConversationUpdate(t *testing.T, resourceName string, createChannel slack.Channel, updateChannel slack.Channel) {
 	var providers []*schema.Provider
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},

--- a/slack/resource_conversation_test.go
+++ b/slack/resource_conversation_test.go
@@ -21,7 +21,7 @@ func TestAccSlackConversationTest(t *testing.T) {
 	resourceName := "slack_conversation.test"
 	namePrefix := "test-acc-slack-conversation-test"
 
-	t.Run("test update name, topic and purpose", func(t *testing.T) {
+	t.Run("update name, topic and purpose", func(t *testing.T) {
 		name := acctest.RandomWithPrefix(namePrefix)
 		createChannel := testAccSlackConversation(name)
 
@@ -31,7 +31,7 @@ func TestAccSlackConversationTest(t *testing.T) {
 		testSlackConversationUpdate(t, resourceName, createChannel, updateChannel)
 	})
 
-	t.Run("test archive channel", func(t *testing.T) {
+	t.Run("archive channel", func(t *testing.T) {
 		name := acctest.RandomWithPrefix(namePrefix)
 		createChannel := testAccSlackConversationWithMembers(name, []string{testUser00.id})
 
@@ -41,7 +41,7 @@ func TestAccSlackConversationTest(t *testing.T) {
 		testSlackConversationUpdate(t, resourceName, createChannel, updateChannel)
 	})
 
-	t.Run("test unarchive channel", func(t *testing.T) {
+	t.Run("unarchive channel", func(t *testing.T) {
 		name := acctest.RandomWithPrefix(namePrefix)
 		createChannel := testAccSlackConversationWithMembers(name, []string{testUser00.id})
 		createChannel.IsArchived = true
@@ -52,7 +52,7 @@ func TestAccSlackConversationTest(t *testing.T) {
 		testSlackConversationUpdate(t, resourceName, createChannel, updateChannel)
 	})
 
-	t.Run("test update permanent members", func(t *testing.T) {
+	t.Run("update permanent members", func(t *testing.T) {
 		name := acctest.RandomWithPrefix(namePrefix)
 		createChannel := testAccSlackConversationWithMembers(name, []string{testUser00.id})
 

--- a/slack/resource_conversation_test.go
+++ b/slack/resource_conversation_test.go
@@ -98,7 +98,6 @@ func testSlackConversationUpdate(t *testing.T, resourceName string, createChanne
 }
 
 func testCheckResourceAttrBasic(resourceName string, channel slack.Channel) resource.TestCheckFunc {
-//	members := append(channel.Members, testUserCreator.id)
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(resourceName, "name", channel.Name),
 		resource.TestCheckResourceAttr(resourceName, "topic", channel.Topic.Value),
@@ -111,7 +110,6 @@ func testCheckResourceAttrBasic(resourceName string, channel slack.Channel) reso
 		resource.TestCheckResourceAttr(resourceName, "is_ext_shared", fmt.Sprintf("%t", channel.IsExtShared)),
 		resource.TestCheckResourceAttr(resourceName, "is_general", fmt.Sprintf("%t", channel.IsGeneral)),
 		testCheckResourceAttrSlice(resourceName, "permanent_members", channel.Members),
-//		testCheckResourceAttrSlice(resourceName, "members", members),
 	)
 }
 

--- a/slack/resource_conversation_test.go
+++ b/slack/resource_conversation_test.go
@@ -98,7 +98,7 @@ func testSlackConversationUpdate(t *testing.T, resourceName string, createChanne
 }
 
 func testCheckResourceAttrBasic(resourceName string, channel slack.Channel) resource.TestCheckFunc {
-	//members := append(channel.Members, testUserCreator.id)
+//	members := append(channel.Members, testUserCreator.id)
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(resourceName, "name", channel.Name),
 		resource.TestCheckResourceAttr(resourceName, "topic", channel.Topic.Value),
@@ -111,7 +111,7 @@ func testCheckResourceAttrBasic(resourceName string, channel slack.Channel) reso
 		resource.TestCheckResourceAttr(resourceName, "is_ext_shared", fmt.Sprintf("%t", channel.IsExtShared)),
 		resource.TestCheckResourceAttr(resourceName, "is_general", fmt.Sprintf("%t", channel.IsGeneral)),
 		testCheckResourceAttrSlice(resourceName, "permanent_members", channel.Members),
-	//	testCheckResourceAttrSlice(resourceName, "members", members),
+//		testCheckResourceAttrSlice(resourceName, "members", members),
 	)
 }
 
@@ -144,7 +144,7 @@ func testCheckSlackChannelAttributes(t *testing.T, resourceName string, expected
 			ChannelID: channel.ID,
 		})
 		if err != nil {
-			return fmt.Errorf("couldn't get channelUsers in conversation for %s: %s", channel.ID, err)
+			return fmt.Errorf("couldn't get users in conversation for %s: %s", channel.ID, err)
 		}
 		definedMembers := expectedChannel.Members
 		assertUsersInStateAreInTheChannel(t, primary, definedMembers, channelUsers)

--- a/slack/resource_conversation_test.go
+++ b/slack/resource_conversation_test.go
@@ -21,13 +21,11 @@ func TestAccSlackConversationTest(t *testing.T) {
 
 	name := acctest.RandomWithPrefix("test-acc-slack-conversation-test")
 	var permanentMembers []string
-	var expectedMembers = []string{testUserCreator.id}
 	createChannel := testAccSlackConversation(name, permanentMembers)
 
 	var updatedPermanentMembers = []string{testUser00.id}
 	sort.Strings(updatedPermanentMembers)
-	var updatedExpectedMembers = []string{testUserCreator.id, testUser00.id}
-	sort.Strings(updatedExpectedMembers)
+
 	updateName := acctest.RandomWithPrefix("test-acc-slack-conversation-test-update")
 	updateChannel := testAccSlackConversation(updateName, updatedPermanentMembers)
 	updateChannel.ID = createChannel.ID
@@ -43,20 +41,7 @@ func TestAccSlackConversationTest(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSlackConversationConfig(createChannel),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", createChannel.Name),
-					resource.TestCheckResourceAttr(resourceName, "topic", createChannel.Topic.Value),
-					resource.TestCheckResourceAttr(resourceName, "purpose", createChannel.Purpose.Value),
-					resource.TestCheckResourceAttr(resourceName, "creator", testUserCreator.id),
-					resource.TestCheckResourceAttr(resourceName, "is_private", fmt.Sprintf("%t", createChannel.IsPrivate)),
-					resource.TestCheckResourceAttr(resourceName, "is_archived", fmt.Sprintf("%t", createChannel.IsArchived)),
-					resource.TestCheckResourceAttr(resourceName, "is_shared", fmt.Sprintf("%t", createChannel.IsShared)),
-					resource.TestCheckResourceAttr(resourceName, "is_org_shared", fmt.Sprintf("%t", createChannel.IsOrgShared)),
-					resource.TestCheckResourceAttr(resourceName, "is_ext_shared", fmt.Sprintf("%t", createChannel.IsExtShared)),
-					resource.TestCheckResourceAttr(resourceName, "is_general", fmt.Sprintf("%t", createChannel.IsGeneral)),
-					testCheckResourceAttrSlice(resourceName, "permanent_members", permanentMembers),
-					testCheckResourceAttrSlice(resourceName, "members", expectedMembers),
-				),
+				Check:  testCheckResourceAttrBasic(resourceName, createChannel),
 			},
 			{
 				ResourceName:            resourceName,
@@ -66,23 +51,28 @@ func TestAccSlackConversationTest(t *testing.T) {
 			},
 			{
 				Config: testAccSlackConversationConfig(updateChannel),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", updateChannel.Name),
-					resource.TestCheckResourceAttr(resourceName, "topic", updateChannel.Topic.Value),
-					resource.TestCheckResourceAttr(resourceName, "purpose", updateChannel.Purpose.Value),
-					resource.TestCheckResourceAttr(resourceName, "creator", testUserCreator.id),
-					resource.TestCheckResourceAttr(resourceName, "is_private", fmt.Sprintf("%t", updateChannel.IsPrivate)),
-					resource.TestCheckResourceAttr(resourceName, "is_archived", fmt.Sprintf("%t", updateChannel.IsArchived)),
-					resource.TestCheckResourceAttr(resourceName, "is_shared", fmt.Sprintf("%t", updateChannel.IsShared)),
-					resource.TestCheckResourceAttr(resourceName, "is_org_shared", fmt.Sprintf("%t", updateChannel.IsOrgShared)),
-					resource.TestCheckResourceAttr(resourceName, "is_ext_shared", fmt.Sprintf("%t", updateChannel.IsExtShared)),
-					resource.TestCheckResourceAttr(resourceName, "is_general", fmt.Sprintf("%t", updateChannel.IsGeneral)),
-					testCheckResourceAttrSlice(resourceName, "permanent_members", updatedPermanentMembers),
-					//testCheckResourceAttrSlice(resourceName, "members", updatedExpectedMembers),
-				),
+				Check:  testCheckResourceAttrBasic(resourceName, updateChannel),
 			},
 		},
 	})
+}
+
+func testCheckResourceAttrBasic(resourceName string, channel slack.Channel) resource.TestCheckFunc {
+	//	members := append(channel.Members, testUserCreator.id)
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(resourceName, "name", channel.Name),
+		resource.TestCheckResourceAttr(resourceName, "topic", channel.Topic.Value),
+		resource.TestCheckResourceAttr(resourceName, "purpose", channel.Purpose.Value),
+		resource.TestCheckResourceAttr(resourceName, "creator", testUserCreator.id),
+		resource.TestCheckResourceAttr(resourceName, "is_private", fmt.Sprintf("%t", channel.IsPrivate)),
+		resource.TestCheckResourceAttr(resourceName, "is_archived", fmt.Sprintf("%t", channel.IsArchived)),
+		resource.TestCheckResourceAttr(resourceName, "is_shared", fmt.Sprintf("%t", channel.IsShared)),
+		resource.TestCheckResourceAttr(resourceName, "is_org_shared", fmt.Sprintf("%t", channel.IsOrgShared)),
+		resource.TestCheckResourceAttr(resourceName, "is_ext_shared", fmt.Sprintf("%t", channel.IsExtShared)),
+		resource.TestCheckResourceAttr(resourceName, "is_general", fmt.Sprintf("%t", channel.IsGeneral)),
+		testCheckResourceAttrSlice(resourceName, "permanent_members", channel.Members),
+		//testCheckResourceAttrSlice(resourceName, "members", members),
+	)
 }
 
 func testCheckResourceAttrSlice(resourceName string, key string, a []string) resource.TestCheckFunc {


### PR DESCRIPTION
Removed read current members support as it causes all sort of troubles synchronising stat.

On top of that this PR:

- Removes code duplication from code and tests
- Adds test cases for archive/unarchive channels
- Adds test cases for name/topic/purpose updates 
- Adds test cases for permanent members updates
- Adds assertions agains the Slack backend