### PR TITLE
Added search by email support to user data source

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -24,7 +24,7 @@ fmt:
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
-lint: tools fmtcheck vet #docs
+lint: tools fmtcheck vet docs
 	@echo "==> Checking source code against linters..."
 	golint -set_exit_status $$(find . -type d | grep -v vendor)
 	ineffassign .

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -11,8 +11,12 @@ resources.
 ## Example Usage
 
 ```hcl
-data slack_user test {
+data slack_user by_name {
   name = "my-user"
+}
+
+data slack_user by_email {
+  email = "my-user@example.com"
 }
 ```
 
@@ -20,7 +24,10 @@ data slack_user test {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the user
+* `name` - (Optional) The name of the user
+* `email` - (Optional) The email of the user
+
+The data source expects exactly one of these fields, you can't set both.
 
 ## Attribute Reference
 

--- a/slack/data_source_user.go
+++ b/slack/data_source_user.go
@@ -14,8 +14,14 @@ func dataSourceUser() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"name", "email"},
+			},
+			"email": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"name", "email"},
 			},
 		},
 	}
@@ -26,36 +32,59 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	client := m.(*slack.Client)
 
-	users, err := client.GetUsersContext(ctx)
-	if err != nil {
-		return diag.Errorf("couldn't get workspace users: %s", err)
-	}
-
-	var matchingUsers []slack.User
-	for _, user := range users {
-		if user.Name == d.Get("name") {
-			matchingUsers = append(matchingUsers, user)
+	var user *slack.User
+	if name, ok := d.GetOk("name"); ok {
+		u, err := searchByName(ctx, name.(string), client)
+		if err != nil {
+			return diag.FromErr(err)
 		}
+		user = u
 	}
 
-	if len(matchingUsers) < 1 {
+	if email, ok := d.GetOk("email"); ok {
+		u, err := client.GetUserByEmailContext(ctx, email.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		user = u
+	}
+
+	if user == nil {
 		return diag.Errorf("your query returned no results. Please change your search criteria and try again")
 	}
-
-	if len(matchingUsers) > 1 {
-		return diag.Errorf("your query returned more than one result. Please try a more specific search criteria")
-	}
-
-	user := matchingUsers[0]
 
 	d.SetId(user.ID)
 	if err := d.Set("name", user.Name); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting name: %s", err))
 	}
 
-	if err := d.Set("name", user.Name); err != nil {
+	if err := d.Set("email", user.Profile.Email); err != nil {
 		return diag.Errorf("error setting name: %s", err)
 	}
 
 	return diags
+}
+
+func searchByName(ctx context.Context, name string, client *slack.Client) (*slack.User, error) {
+	users, err := client.GetUsersContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get workspace users: %s", err)
+	}
+
+	var matchingUsers []slack.User
+	for _, user := range users {
+		if user.Name == name {
+			matchingUsers = append(matchingUsers, user)
+		}
+	}
+
+	if len(matchingUsers) < 1 {
+		return nil, fmt.Errorf("your query returned no results. Please change your search criteria and try again")
+	}
+
+	if len(matchingUsers) > 1 {
+		return nil, fmt.Errorf("your query returned more than one result. Please try a more specific search criteria")
+	}
+
+	return &matchingUsers[0], nil
 }

--- a/slack/provider_test.go
+++ b/slack/provider_test.go
@@ -7,24 +7,28 @@ import (
 )
 
 type testUser struct {
-	id   string
-	name string
+	id    string
+	name  string
+	email string
 }
 
 var (
 	testUserCreator = testUser{
-		id:   "U01D6L97N0M",
-		name: "contact",
+		id:    "U01D6L97N0M",
+		name:  "contact",
+		email: "contact@pablovarela.co.uk",
 	}
 
 	testUser00 = testUser{
-		id:   "U01D31S1GUE",
-		name: "contact_test-user-ter",
+		id:    "U01D31S1GUE",
+		name:  "contact_test-user-ter",
+		email: "contact+test-user-terraform-provider-slack-00@pablovarela.co.uk",
 	}
 
 	testUser01 = testUser{
-		id:   "U01DZK10L1W",
-		name: "contact_test-user-206",
+		id:    "U01DZK10L1W",
+		name:  "contact_test-user-206",
+		email: "contact+test-user-terraform-provider-slack-01@pablovarela.co.uk",
 	}
 )
 


### PR DESCRIPTION
Added search by email support to user data source. Example:
```hcl
data slack_user test {
 email = "test@example.com"
}

resource slack_conversation aws_chatbot {
  name              = "aws-chat-bot-notifications-pablo"
  topic             = "AWS ChatBot Notifications"
  permanent_members = [data.slack_user.test.id]
  is_private        = true
}
```