### PR TITLE
fix for failing acceptance test:

### DIFF
--- a/slack/resource_conversation_test.go
+++ b/slack/resource_conversation_test.go
@@ -144,7 +144,7 @@ func testSlackConversationUpdate(t *testing.T, resourceName string, createChanne
 			ResourceName:            resourceName,
 			ImportState:             true,
 			ImportStateVerify:       true,
-			ImportStateVerifyIgnore: []string{"permanent_members"},
+			ImportStateVerifyIgnore: []string{"permanent_members", "action_on_destroy"},
 		},
 	}
 


### PR DESCRIPTION
tests threw the error 'ImportStateVerify attributes not equivalent'
as per https://www.terraform.io/plugin/sdkv2/resources/import\#importstateverifyignore-1 added action_on_destroy to ImportStateVerifyIgnore