### PR TITLE
Replaced deprecated OAuth Scope

### DIFF
--- a/docs/resources/conversation.md
+++ b/docs/resources/conversation.md
@@ -12,7 +12,7 @@ Manages a Slack channel
 This resource requires the following scopes:
 
 - [channels:read](https://api.slack.com/scopes/channels:read) (public channels)
-- [channels:write](https://api.slack.com/scopes/channels:write) (public channels)
+- [channels:manage](https://api.slack.com/scopes/channels:manage) (public channels)
 - [groups:read](https://api.slack.com/scopes/groups:read) (private channels)
 - [groups:write](https://api.slack.com/scopes/groups:write) (private channels)
 


### PR DESCRIPTION
The OAuth Scope `channels:write` no longer supports `bot` tokens. I replaced this permissions with `channels:manage`, and was able to create and delete a public and private channels with the following configuration.

```terraform
resource "slack_conversation" "test" {
  name              = "my-channel-1121311"
  topic             = "The topic for my channel"
  permanent_members = []
  is_private        = false
  action_on_destroy = "archive"
}

resource "slack_conversation" "test_private" {
  name              = "my-channel-1121311-private"
  topic             = "The topic for my channel"
  permanent_members = ["01234567890"]
  is_private        = true
  action_on_destroy = "archive"
}

```

https://api.slack.com/scopes/channels:write

https://api.slack.com/scopes/channels:manage