### PR TITLE
feat: action action_on_update_permanent_members

### DIFF
--- a/docs/resources/conversation.md
+++ b/docs/resources/conversation.md
@@ -68,6 +68,10 @@ conversation should be archived or left behind on destroy. Valid values are
 `archive | none`. Note that when set to `none` the conversation will be left
 as it is  and as a result any subsequent runs of terraform apply with the same
 name  will fail.
+- `action_on_update_permanent_members` - (Optional, Default `kick`) indicate
+whether the members should be kick of the channel when removed from
+`permanent_members`. When set to `none` the user are never kicked, this prevent
+ a side effect on public channels where user that joined the channel are kicked.
 
 ## Attribute Reference
 


### PR DESCRIPTION
The feature of kicking user is problematic when dealing with public channels. In that case users can  join on their own but you will kick them next time the channel premanant_members is updated


The `none` option is the best way the handle this case in my opinion.
