### PR TITLE
Passed the wrong usergroup.ID

### DIFF
--- a/slack/resource_usergroup.go
+++ b/slack/resource_usergroup.go
@@ -86,9 +86,9 @@ func resourceSlackUserGroupCreate(ctx context.Context, d *schema.ResourceData, m
 				return diag.Errorf("could not enable usergroup %s (%s): %s", name, group.ID, err)
 			}
 		}
-		_, err = client.UpdateUserGroupContext(ctx, createdUserGroup.ID)
+		_, err = client.UpdateUserGroupContext(ctx, group.ID)
 		if err != nil {
-			return diag.Errorf("could not update usergroup %s: %s", name, err)
+			return diag.Errorf("could not update usergroup %s (%s): %s", name, group.ID, err)
 		}
 		d.SetId(createdUserGroup.ID)
 	} else {


### PR DESCRIPTION
Got this error while trying to update (an existing userlist).

`Error: could not update usergroup xyz: invalid_arguments`

Looked at the code, and found this reference to createdUserGroup which should be nil (i think)