### PR TITLE
Fixup, missed a createdUserGroup.ID

### DIFF
--- a/slack/resource_usergroup.go
+++ b/slack/resource_usergroup.go
@@ -90,7 +90,7 @@ func resourceSlackUserGroupCreate(ctx context.Context, d *schema.ResourceData, m
 		if err != nil {
 			return diag.Errorf("could not update usergroup %s (%s): %s", name, group.ID, err)
 		}
-		d.SetId(createdUserGroup.ID)
+		d.SetId(group.ID)
 	} else {
 		d.SetId(createdUserGroup.ID)
 	}


### PR DESCRIPTION
My previous PR didnt fix my issue. Now getting this error:

```
│ When applying changes to slack_usergroup.XXX, provider
│ "provider[\"registry.terraform.io/pablovarela/slack\"]" produced an
│ unexpected new value: Root resource was present, but now absent.
│ 
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
```

While browsing the code, found this reference to createdUserGroup.ID which had to be replaced by group.ID.