### PR TITLE
Fix confusion of "AWS" to "Slack" provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,7 @@ terraform plan
 ## Argument Reference
 
 In addition to [generic `provider` arguments](https://www.terraform.io/docs/configuration/providers.html)
-(e.g. `alias` and `version`), the following arguments are supported in the AWS
+(e.g. `alias` and `version`), the following arguments are supported in the Slack
  `provider` block:
 
 - `token` - (Mandatory) The Slack token. It must be provided,


### PR DESCRIPTION
Am I right that this was a copy and paste issue?