### PR TITLE
Allow data source conversation to look up channels by name.

### DIFF
--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -228,7 +228,7 @@ func findExistingChannel(ctx context.Context, client *slack.Client, name string,
 		}
 	}
 	// looked through entire list, but didn't find matching name
-	return nil, fmt.Errorf("name_taken, but could not find channel")
+	return nil, fmt.Errorf("could not find channel with name %s", name)
 }
 
 func updateChannelMembers(ctx context.Context, d *schema.ResourceData, client *slack.Client, channelID string) error {


### PR DESCRIPTION
Reuse the channel search logic implemented for adopting existing channel resources.