### PR TITLE
Fix updating usergroup data

### DIFF
--- a/slack/resource_usergroup.go
+++ b/slack/resource_usergroup.go
@@ -221,7 +221,7 @@ func updateUserGroupData(d *schema.ResourceData, userGroup slack.UserGroup) diag
 		return diag.Errorf("error setting description: %s", err)
 	}
 
-	if err := d.Set("channels", userGroup.Prefs.Channels); err != nil {
+	if err := d.Set("channels", append(userGroup.Prefs.Channels, userGroup.Prefs.Groups...)); err != nil {
 		return diag.Errorf("error setting channels: %s", err)
 	}
 


### PR DESCRIPTION
Thanks for terraform-provider-slack.

When a channel with `G` prefix is configured in a usergroup, the terraform plan shows differences after updating usergroups.
So I've added the `userGroup.Prefs.Groups` to the channels.