### PR TITLE
Preserve existing topics and descriptions if they are null in the terraform configuration

### DIFF
--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -331,16 +331,20 @@ func resourceSlackConversationUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if d.HasChange("topic") {
-		topic := d.Get("topic")
-		if _, err := client.SetTopicOfConversationContext(ctx, id, topic.(string)); err != nil {
-			return diag.Errorf("couldn't set conversation topic %s: %s", topic.(string), err)
+		topic, exists := d.GetOk("topic")
+		if exists {
+			if _, err := client.SetTopicOfConversationContext(ctx, id, topic.(string)); err != nil {
+				return diag.Errorf("couldn't set conversation topic %s: %s", topic.(string), err)
+			}
 		}
 	}
 
 	if d.HasChange("purpose") {
-		purpose := d.Get("purpose")
-		if _, err := client.SetPurposeOfConversationContext(ctx, id, purpose.(string)); err != nil {
-			return diag.Errorf("couldn't set conversation purpose %s: %s", purpose.(string), err)
+		purpose, exists := d.GetOk("purpose")
+		if exists {
+			if _, err := client.SetPurposeOfConversationContext(ctx, id, purpose.(string)); err != nil {
+				return diag.Errorf("couldn't set conversation purpose %s: %s", purpose.(string), err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Thanks for this provider! I'm currently trying to move off from a custom slack configuration tool to a terraform-based one via this provider. However, I have hit a pain point while doing so:

This provider takes full control of channels when trying to manage existing conversations, and results in existing metadata getting deleted. Although this might be preferable in some cases, this is a bit unexpected for groups with existing slack setups.

This PR changes the provider behavior so that topics and purposes are not modified when they are `null`/missing in the terraform configuration.