### PR TITLE
Add "users list" datasource

### DIFF
--- a/docs/data-sources/users_list.md
+++ b/docs/data-sources/users_list.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Slack"
+page_title: "Slack: slack_users_list"
+---
+
+# slack_users_list Data Source
+
+Use this data source to get a list of users for use in other
+resources. 
+
+This resource is quite slow and should be used with caution. 
+It lists any user, including the deleted (deactivated) ones
+
+## Required scopes
+
+This resource requires the following scopes:
+
+- [users:read](https://api.slack.com/scopes/users:read)
+- [users:read.email](https://api.slack.com/scopes/users:read.email)
+
+The Slack API methods used by the resource are:
+
+- [users.list](https://api.slack.com/methods/users.list)
+
+If you get `missing_scope` errors while using this resource check the scopes against
+the documentation for the methods above.
+
+## Example Usage
+
+```hcl
+data "slack_users_list" "all" {
+}
+
+data "slack_users_list" "by_email" {
+  email = "my-user@example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `email` - (Optional) Filters the list of users by email
+
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `users` - The list of users
+
+Each `user` has these attributes : 
+- `deleted` - Whether the user is deleted (deactivated)
+- `email` - The email of the user
+- `id` - The ID of the user
+- `name` - The name of the user
+- `real_name` - The real name of the user

--- a/slack/data_source_users_list.go
+++ b/slack/data_source_users_list.go
@@ -1,0 +1,110 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/slack-go/slack"
+)
+
+func dataSourceUsersList() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceUsersListRead,
+
+		Schema: map[string]*schema.Schema{
+			"users": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"email": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"real_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"deleted": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceUsersListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	client := m.(*slack.Client)
+
+	var users []slack.User
+
+	us, err := client.GetUsersContext(ctx)
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error fetching users list: %w", err))
+	}
+
+	var id string
+	if email, ok := d.GetOk("email"); ok {
+		users = filterByEmail(us, email.(string))
+		id = email.(string)
+	} else {
+		users = us
+		id = "all"
+	}
+
+	d.SetId(id)
+	if err := d.Set("users", usersToMap(users)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting name: %s", err))
+	}
+
+	return diags
+}
+
+func filterByEmail(users []slack.User, email string) []slack.User {
+	var res []slack.User
+	for _, user := range users {
+		if user.Profile.Email == email {
+			res = append(res, user)
+		}
+	}
+	return res
+}
+
+func usersToMap(users []slack.User) []map[string]interface{} {
+	var res []map[string]interface{}
+	for _, user := range users {
+		res = append(res, userToMap(user))
+	}
+	return res
+}
+
+func userToMap(user slack.User) map[string]interface{} {
+	res := map[string]interface{}{
+		"id":        user.ID,
+		"name":      user.Name,
+		"email":     user.Profile.Email,
+		"real_name": user.RealName,
+		"deleted":   user.Deleted,
+	}
+	return res
+}

--- a/slack/data_source_users_list_test.go
+++ b/slack/data_source_users_list_test.go
@@ -1,0 +1,81 @@
+package slack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccSlackUsersListDataSource_basic(t *testing.T) {
+	t.Parallel()
+	dataSourceName := "data.slack_users_list.test"
+
+	var providers []*schema.Provider
+
+	t.Run("list all", func(t *testing.T) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:          func() { testAccPreCheck(t) },
+			ProviderFactories: testAccProviderFactories(&providers),
+			Steps: []resource.TestStep{
+				{
+					Config: testAccCheckSlackUsersListDataSourceConfigListAll,
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckSlackUsersListDataSourceID(dataSourceName),
+						resource.TestCheckResourceAttrSet(dataSourceName, "users.#"),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("list by email", func(t *testing.T) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:          func() { testAccPreCheck(t) },
+			ProviderFactories: testAccProviderFactories(&providers),
+			Steps: []resource.TestStep{
+				{
+					Config: testAccCheckSlackUsersListDataSourceConfigListByEmail,
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckSlackUsersListDataSourceID(dataSourceName),
+						resource.TestCheckResourceAttr(dataSourceName, "users.#", "1"),
+						resource.TestCheckResourceAttr(dataSourceName, "users.0.name", testUser00.name),
+						resource.TestCheckResourceAttr(dataSourceName, "users.0.email", testUser00.email),
+						resource.TestCheckResourceAttr(dataSourceName, "users.0.id", testUser00.id),
+					),
+				},
+			},
+		})
+	})
+}
+
+func testAccCheckSlackUsersListDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find slack users list datasource: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("slack  users list datasource id not set")
+		}
+		return nil
+	}
+}
+
+const (
+	testAccCheckSlackUsersListDataSourceConfigListAll = `
+data slack_users_list test {
+}
+`
+)
+
+var (
+	testAccCheckSlackUsersListDataSourceConfigListByEmail = fmt.Sprintf(`
+data slack_users_list test {
+  email = "%s"
+}
+`, testUser00.email)
+)

--- a/slack/provider.go
+++ b/slack/provider.go
@@ -28,6 +28,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"slack_conversation": dataSourceConversation(),
 			"slack_user":         dataSourceUser(),
+			"slack_users_list":   dataSourceUsersList(),
 			"slack_usergroup":    dataSourceUserGroup(),
 		},
 


### PR DESCRIPTION
This adds a `slack_user_list` datasource.

In particular, it can be used to work around #252 while being aware that the datasource will perform a costy lookup.
